### PR TITLE
Fix code scanning alert no. 6: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/pkg/dockersync/dockersync.go
+++ b/pkg/dockersync/dockersync.go
@@ -233,7 +233,17 @@ func extractTar(ctx context.Context, tarPath, destPath string) error {
 			return fmt.Errorf("tar reading error: %w", err)
 		}
 
+		// Ensure the header name does not contain ".."
+		if strings.Contains(header.Name, "..") {
+			return fmt.Errorf("invalid file path in tar archive: %s", header.Name)
+		}
+
+		// Clean the target path and ensure it is within destPath
 		target := filepath.Join(destPath, header.Name)
+		target = filepath.Clean(target)
+		if !strings.HasPrefix(target, filepath.Clean(destPath)+string(os.PathSeparator)) {
+			return fmt.Errorf("invalid file path in tar archive: %s", header.Name)
+		}
 
 		switch header.Typeflag {
 		case tar.TypeDir:


### PR DESCRIPTION
Fixes [https://github.com/yarlson/ftl/security/code-scanning/6](https://github.com/yarlson/ftl/security/code-scanning/6)

To fix the problem, we need to ensure that the paths extracted from the tar archive do not contain any directory traversal sequences like `..`. This can be done by validating the `header.Name` before using it to construct the target path. We should also ensure that the target path is within the intended destination directory.

1. Add a check to ensure that `header.Name` does not contain `..`.
2. Use `filepath.Clean` to normalize the path and ensure it is within the `destPath` directory.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
