### PR TITLE
Restrict deployment to single server configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FTL (Faster Than Light) Deployment
 
-FTL is a lightweight deployment tool designed to simplify cloud deployments without the complexity of traditional CI/CD pipelines or container orchestration platforms. It provides automated, zero-downtime deployments to various cloud providers through a single YAML configuration file.
+FTL is a lightweight deployment tool designed to simplify cloud deployments without the complexity of traditional CI/CD pipelines or container orchestration platforms. It provides automated, zero-downtime deployments through a single YAML configuration file.
 
 For comprehensive documentation, visit [https://ftl-deploy.org](https://ftl-deploy.org)
 
@@ -62,14 +62,14 @@ project:
   domain: my-project.example.com
   email: my-project@example.com
 
-servers:
-  - host: my-project.example.com
-    port: 22
-    user: my-project
-    ssh_key: ~/.ssh/id_rsa
+server:
+  host: my-project.example.com
+  port: 22
+  user: my-project
+  ssh_key: ~/.ssh/id_rsa
 
 services:
-  - name: my-app
+  - name: web
     image: my-app:latest
     port: 80
     health_check:
@@ -160,9 +160,6 @@ ftl logs my-app -n 150
 ```bash
 # Create tunnels for all dependencies
 ftl tunnels
-
-# Connect to specific server
-ftl tunnels --server my-project.example.com
 ```
 
 ## Development

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -18,8 +18,8 @@ import (
 
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
-	Short: "Deploy your application to configured servers",
-	Long: `Deploy your application to all servers defined in ftl.yaml.
+	Short: "Deploy your application to configured server",
+	Long: `Deploy your application to the server defined in ftl.yaml.
 This command handles the entire deployment process, ensuring
 zero-downtime updates of your services.`,
 	Run: runDeploy,
@@ -39,14 +39,13 @@ func runDeploy(cmd *cobra.Command, args []string) {
 	sm := console.NewSpinnerManager()
 	sm.Start()
 
-	if err := deployToServers(cfg, sm); err != nil {
+	if err := deployToServer(cfg.Project.Name, cfg, cfg.Server, sm); err != nil {
 		sm.Stop()
-		console.Error("Deployment failed")
+		console.Error("Deployment failed:", err)
 		return
 	}
 
 	sm.Stop()
-
 	console.Success("Deployment completed successfully")
 }
 
@@ -62,16 +61,6 @@ func parseConfig(filename string) (*config.Config, error) {
 	}
 
 	return cfg, nil
-}
-
-func deployToServers(cfg *config.Config, sm *console.SpinnerManager) error {
-	for _, server := range cfg.Servers {
-		if err := deployToServer(cfg.Project.Name, cfg, server, sm); err != nil {
-			return fmt.Errorf("failed to deploy to server %s: %w", server.Host, err)
-		}
-	}
-
-	return nil
 }
 
 func deployToServer(project string, cfg *config.Config, server config.Server, sm *console.SpinnerManager) error {

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -15,8 +15,8 @@ import (
 
 var setupCmd = &cobra.Command{
 	Use:   "setup",
-	Short: "Prepare servers for deployment",
-	Long: `Setup configures servers defined in ftl.yaml for deployment.
+	Short: "Prepare server for deployment",
+	Long: `Setup configures server defined in ftl.yaml for deployment.
 Run this once for each new server before deploying your application.`,
 	Run: runSetup,
 }
@@ -66,7 +66,11 @@ func runSetup(cmd *cobra.Command, args []string) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
-	if err := server.SetupServers(ctx, cfg, dockerCreds, newUserPassword, sm); err != nil {
+	if err := server.Setup(ctx, cfg, server.DockerCredentials{
+		Username: dockerCreds.Username,
+		Password: dockerCreds.Password,
+	}, newUserPassword, sm); err != nil {
+		sm.Stop()
 		console.Error("Setup failed:", err)
 		return
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,7 +19,7 @@ import (
 
 type Config struct {
 	Project      Project      `yaml:"project" validate:"required"`
-	Servers      []Server     `yaml:"servers" validate:"required,dive"`
+	Server       Server       `yaml:"server" validate:"required"`
 	Services     []Service    `yaml:"services" validate:"required,dive"`
 	Dependencies []Dependency `yaml:"dependencies" validate:"dive"`
 	Volumes      []string     `yaml:"volumes" validate:"dive"`

--- a/pkg/config/sample/ftl.yaml
+++ b/pkg/config/sample/ftl.yaml
@@ -3,16 +3,11 @@ project:
   domain: my-project.example.com
   email: my-project@example.com
 
-servers:
-  - host: my-project.example.com
-    port: 22
-    user: my-project
-    ssh_key: ~/.ssh/id_rsa
-
-  - host: 127.0.0.1
-    port: 22
-    user: my-project
-    ssh_key: ~/.ssh/id_rsa
+server:
+  host: my-project.example.com
+  port: 22
+  user: my-project
+  ssh_key: ~/.ssh/id_rsa
 
 services:
   - name: my-app

--- a/schemas/ftl-schema.json
+++ b/schemas/ftl-schema.json
@@ -18,26 +18,23 @@
         }
       }
     },
-    "servers": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["host", "port", "user", "ssh_key"],
-        "properties": {
-          "host": {
-            "type": "string",
-            "format": "hostname-or-ip"
-          },
-          "port": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 65535
-          },
-          "user": { "type": "string" },
-          "ssh_key": {
-            "type": "string",
-            "format": "file-path"
-          }
+    "server": {
+      "type": "object",
+      "required": ["host", "port", "user", "ssh_key"],
+      "properties": {
+        "host": {
+          "type": "string",
+          "format": "hostname-or-ip"
+        },
+        "port": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 65535
+        },
+        "user": { "type": "string" },
+        "ssh_key": {
+          "type": "string",
+          "format": "file-path"
         }
       }
     },

--- a/www/docs/configuration/index.md
+++ b/www/docs/configuration/index.md
@@ -12,7 +12,7 @@ FTL uses a single YAML configuration file (`ftl.yaml`) to define your entire dep
 The `ftl.yaml` file is organized into these main sections:
 
 - **Project**: Basic project information like name, domain, and contact details
-- **Servers**: Target server specifications and SSH connection details
+- **Server**: Target server specifications and SSH connection details
 - **Services**: Your application services that will be deployed
 - **Dependencies**: Supporting services like databases and caches
 - **Volumes**: Persistent storage definitions
@@ -25,11 +25,11 @@ project:
   domain: my-project.example.com
   email: admin@example.com
 
-servers:
-  - host: my-project.example.com
-    port: 22
-    user: deploy
-    ssh_key: ~/.ssh/id_rsa
+server:
+  host: my-project.example.com
+  port: 22
+  user: deploy
+  ssh_key: ~/.ssh/id_rsa
 
 services:
   - name: web

--- a/www/docs/core-tasks/building.md
+++ b/www/docs/core-tasks/building.md
@@ -130,14 +130,13 @@ Benefits:
    - Use direct SSH transfer for simpler setups
    - Use registry-based deployment when:
      - You need image versioning
-     - Multiple servers need the same image
      - You require image scanning/signing
 
 2. **Registry Configuration**
 
    - Use username/password authentication
    - Avoid token-based registries (currently unsupported)
-   - Consider registry proximity to your servers
+   - Consider registry proximity to your server
 
 3. **Optimize Dockerfiles**
 

--- a/www/docs/core-tasks/deployment.md
+++ b/www/docs/core-tasks/deployment.md
@@ -21,13 +21,14 @@ The deployment process follows these steps:
 
 1. **SSH Connection**
 
-   - Connects to your configured server(s) via SSH
+   - Connects to your configured server via SSH
    - Verifies server access and permissions
 
 2. **Image Handling**
 
    - For direct SSH transfer (no `image` field):
-     - Transfers Docker images directly to servers
+     - Verifies server access and permissions
+     - Transfers Docker images directly to server
      - Uses FTL's layer caching for optimization
    - For registry-based deployment (`image` field specified):
      - Pulls images from configured registry
@@ -59,6 +60,16 @@ The deployment process follows these steps:
 ### Basic Service Configuration
 
 ```yaml
+project:
+  name: my-project
+  domain: example.com
+  email: admin@example.com
+
+server:
+  host: example.com
+  user: deploy
+  ssh_key: ~/.ssh/id_rsa
+
 services:
   - name: web
     port: 80

--- a/www/docs/core-tasks/index.md
+++ b/www/docs/core-tasks/index.md
@@ -29,7 +29,7 @@ Understand the deployment process and options:
 
 ### [Server Setup](./server-setup.md)
 
-Configure your servers for FTL deployments:
+Configure your server for FTL deployments:
 
 - System requirements
 - Docker installation

--- a/www/docs/core-tasks/server-setup.md
+++ b/www/docs/core-tasks/server-setup.md
@@ -1,11 +1,11 @@
 ---
 title: Server Setup
-description: Learn how to prepare servers for FTL deployments
+description: Learn how to prepare your server for FTL deployment
 ---
 
 # Server Setup
 
-Before deploying applications with FTL, your servers need to be properly configured. This guide covers the server setup process and requirements.
+Before deploying applications with FTL, your server needs to be properly configured. This guide covers the server setup process and requirements.
 
 ## Overview
 
@@ -35,16 +35,7 @@ Execute the setup command:
 ftl setup
 ```
 
-This command will connect to all servers defined in your `ftl.yaml` configuration and perform the necessary setup steps.
-
-::: tip
-To set up a specific server when multiple are configured:
-
-```bash
-ftl setup --server myapp.example.com
-```
-
-:::
+This command will connect to the server defined in your `ftl.yaml` configuration and perform the necessary setup steps.
 
 ## Setup Process
 

--- a/www/docs/core-tasks/tunneling.md
+++ b/www/docs/core-tasks/tunneling.md
@@ -5,7 +5,7 @@ description: Create SSH tunnels to access remote services during development
 
 # Tunneling
 
-FTL can establish SSH tunnels to your remote dependencies, allowing local access to services running on your servers.
+FTL can establish SSH tunnels to your remote dependencies, allowing local access to services running on your server.
 
 ## Basic Usage
 
@@ -14,20 +14,6 @@ Create tunnels to all dependency ports:
 ```bash
 ftl tunnels
 ```
-
-## Command Options
-
-### Server Selection
-
-When multiple servers are configured, specify the target server:
-
-```bash
-ftl tunnels --server my-project.example.com
-```
-
-### Command Flags
-
-- `-s`, `--server <server>`: Specify the server name or index to connect to
 
 ## Purpose
 

--- a/www/docs/getting-started/configuration.md
+++ b/www/docs/getting-started/configuration.md
@@ -17,11 +17,11 @@ project:
   domain: my-project.example.com
   email: my-project@example.com
 
-servers:
-  - host: my-project.example.com
-    port: 22
-    user: my-project
-    ssh_key: ~/.ssh/id_rsa
+server:
+  host: example.com
+  port: 22
+  user: deploy
+  ssh_key: ~/.ssh/id_rsa
 
 services:
   - name: web
@@ -52,30 +52,15 @@ project:
 
 ### Server Configuration
 
-The `servers` section specifies your deployment targets:
+The `server` section specifies your deployment target:
 
 ```yaml
-servers:
-  - host: example.com # Required: Server hostname or IP
-    port: 22 # Optional: SSH port (defaults to 22)
-    user: deploy # Required: SSH user
-    ssh_key: ~/.ssh/id_rsa # Required: Path to SSH private key
+server:
+  host: example.com
+  port: 22
+  user: deploy
+  ssh_key: ~/.ssh/id_rsa
 ```
-
-::: tip Multiple Servers
-You can define multiple servers for load balancing or high availability:
-
-```yaml
-servers:
-  - host: server1.example.com
-    user: deploy
-    ssh_key: ~/.ssh/id_rsa
-  - host: server2.example.com
-    user: deploy
-    ssh_key: ~/.ssh/id_rsa
-```
-
-:::
 
 ### Services
 

--- a/www/docs/getting-started/first-deployment.md
+++ b/www/docs/getting-started/first-deployment.md
@@ -82,7 +82,7 @@ ftl build --skip-push
 
 ### 3. Deploying Your Application
 
-Deploy your application to the configured servers:
+Deploy your application to the configured server:
 
 ```bash
 ftl deploy
@@ -90,7 +90,7 @@ ftl deploy
 
 The deployment process:
 
-1. Connects to your server(s) via SSH
+1. Connects to your server via SSH
 2. Transfers images directly or pulls from registry (depending on configuration)
 3. Sets up volumes and networks
 4. Starts dependencies (if any)
@@ -154,10 +154,10 @@ Here's a complete example of deploying a simple web application:
      domain: myapp.example.com
      email: admin@example.com
 
-   servers:
-     - host: myapp.example.com
-       user: deploy
-       ssh_key: ~/.ssh/id_rsa
+   server:
+     host: myapp.example.com
+     user: deploy
+     ssh_key: ~/.ssh/id_rsa
 
    services:
      - name: web

--- a/www/docs/getting-started/installation.md
+++ b/www/docs/getting-started/installation.md
@@ -125,7 +125,7 @@ If you plan to use a Docker registry, ensure you have:
 
 - Registry URL
 - Username/password credentials (token-based auth not supported)
-- Network access to the registry from both local machine and servers
+- Network access to the registry from both local machine and server
   :::
 
 ## Troubleshooting

--- a/www/docs/guides/zero-downtime.md
+++ b/www/docs/guides/zero-downtime.md
@@ -54,6 +54,16 @@ The health check configuration parameters:
 Proper route configuration ensures traffic is handled correctly during deployments:
 
 ```yaml
+project:
+  name: my-project
+  domain: example.com
+  email: admin@example.com
+
+server:
+  host: example.com
+  user: deploy
+  ssh_key: ~/.ssh/id_rsa
+
 services:
   - name: my-app
     image: my-app:latest

--- a/www/docs/index.md
+++ b/www/docs/index.md
@@ -80,7 +80,7 @@ Deploy your web applications to production servers without complexity. FTL handl
 
 <div class="feature-list">
 
-🚀 Deploy with a single command 
+🚀 Deploy with a single command
 
 🔒 Automatic server security setup
 
@@ -125,20 +125,20 @@ Deploy your web applications to production servers without complexity. FTL handl
 ```yaml
 # Simple configuration - just fill in your details
 project:
-  name: my-website        # Your project name
-  domain: mysite.com      # Your domain name
-  email: me@mysite.com    # Your email for SSL
+  name: my-website # Your project name
+  domain: mysite.com # Your domain name
+  email: me@mysite.com # Your email for SSL
 
 # Your server details from your hosting provider
-servers:
-  - host: 64.23.132.12   # Your server IP
-    user: deploy         
-    ssh_key: ~/.ssh/id_rsa
+server:
+  host: 64.23.132.12 # Your server IP
+  user: deploy
+  ssh_key: ~/.ssh/id_rsa
 
 # Your application
 services:
   - name: website
-    port: 3000           # Your app's port
+    port: 3000 # Your app's port
 
 # Need a database? Just add it here
 dependencies:
@@ -176,6 +176,5 @@ That's it. FTL handles everything else - server setup, security, SSL, databases,
 
 ### When to Consider Alternatives
 
-- Applications needing multiple servers in different regions
 - Large enterprise applications
 - Microservice architectures with many components

--- a/www/docs/reference/cli-commands.md
+++ b/www/docs/reference/cli-commands.md
@@ -11,7 +11,7 @@ This page documents all available FTL CLI commands, their flags, and usage patte
 
 - [`ftl setup`](#setup) - Initialize server with required dependencies
 - [`ftl build`](#build) - Build and prepare application images
-- [`ftl deploy`](#deploy) - Deploy application to configured servers
+- [`ftl deploy`](#deploy) - Deploy application to configured server
 - [`ftl logs`](#logs) - Retrieve and stream logs from services
 - [`ftl tunnels`](#tunnels) - Create SSH tunnels to remote dependencies
 
@@ -81,7 +81,7 @@ ftl build --skip-push
 
 ## Deploy
 
-Deploys the application to configured servers.
+Deploys the application to configured server.
 
 ```bash
 ftl deploy
@@ -91,7 +91,7 @@ ftl deploy
 
 The deploy command performs these operations:
 
-- Connects to configured servers via SSH
+- Connects to configured server via SSH
 - Pulls/transfers required Docker images
 - Performs zero-downtime container replacement
 - Configures Nginx reverse proxy
@@ -147,14 +147,8 @@ ftl logs my-app -n 150
 Creates SSH tunnels to remote dependencies.
 
 ```bash
-ftl tunnels [flags]
+ftl tunnels
 ```
-
-### Flags
-
-| Flag                      | Description                                                  |
-| ------------------------- | ------------------------------------------------------------ |
-| `-s`, `--server <server>` | (Optional) Specify server name/index for multi-server setups |
 
 ### Description
 
@@ -163,16 +157,12 @@ The tunnels command:
 - Establishes SSH tunnels to dependency services
 - Enables local access to remote services
 - Maintains concurrent tunnel connections
-- Supports multiple server configurations
 
 ### Examples
 
 ```bash
 # Establish tunnels to all dependency ports
 ftl tunnels
-
-# Connect to specific server
-ftl tunnels --server my-project.example.com
 ```
 
 ## Environment Variables

--- a/www/docs/reference/configuration-file.md
+++ b/www/docs/reference/configuration-file.md
@@ -11,7 +11,7 @@ FTL uses a YAML configuration file (`ftl.yaml`) to define project settings, serv
 
 ```yaml
 project: # Project-level configuration
-servers: # Server definitions
+server: # Server definition
 services: # Application services
 dependencies: # Supporting services
 volumes: # Persistent storage definitions
@@ -36,14 +36,14 @@ project:
 
 ## Server Configuration
 
-Defines the target servers for deployment.
+Defines the target server for deployment.
 
 ```yaml
-servers:
-  - host: my-project.example.com # Required: Server hostname or IP
-    port: 22 # Optional: SSH port (default: 22)
-    user: my-project # Required: SSH user
-    ssh_key: ~/.ssh/id_rsa # Required: Path to SSH private key
+server:
+  host: my-project.example.com # Required: Server hostname or IP
+  port: 22 # Optional: SSH port (default: 22)
+  user: my-project # Required: SSH user
+  ssh_key: ~/.ssh/id_rsa # Required: Path to SSH private key
 ```
 
 | Field     | Type    | Required | Default | Description                     |
@@ -141,11 +141,11 @@ project:
   domain: my-project.example.com
   email: my-project@example.com
 
-servers:
-  - host: my-project.example.com
-    port: 22
-    user: my-project
-    ssh_key: ~/.ssh/id_rsa
+server:
+  host: my-project.example.com
+  port: 22
+  user: my-project
+  ssh_key: ~/.ssh/id_rsa
 
 services:
   - name: my-app

--- a/www/docs/reference/index.md
+++ b/www/docs/reference/index.md
@@ -26,13 +26,11 @@ FTL supports two distinct approaches for managing Docker images:
    - Builds images locally
    - Implements custom layer caching
    - Transfers only modified layers via SSH
-   - Optimized for single-server deployments
 
 2. **Registry-based Deployment**
    - Activated when `image` field is specified
    - Requires registry authentication (username/password only)
    - Follows standard Docker registry workflow
-   - Suitable for multi-server deployments
 
 ### Deployment Process
 

--- a/www/docs/reference/troubleshooting.md
+++ b/www/docs/reference/troubleshooting.md
@@ -33,9 +33,9 @@ Error: failed to transfer image layers
 
 **Solution**:
 
-- Check SSH connectivity to your server
+- Check SSH connectivity
 - Verify SSH key permissions (should be 600)
-- Ensure sufficient disk space on both local and remote machines
+- Ensure sufficient disk space on both local and server machines
 
 ## Deployment Issues
 
@@ -65,7 +65,7 @@ Error: failed to obtain SSL certificate
 **Solution**:
 
 - Verify DNS records are properly configured
-- Ensure the domain points to your server's IP
+- Ensure the domain points to the server IP
 - Check that port 80 is accessible (required for ACME challenges)
 - Verify the email address in your project configuration
 
@@ -81,10 +81,9 @@ Error: ssh: connect to host example.com port 22: Connection refused
 
 **Solution**:
 
-- Verify server SSH configuration
-- Check firewall rules
-- Ensure correct SSH key path in `ftl.yaml`
-- Verify server hostname/IP and port
+- Verify SSH configuration
+- Verify hostname/IP and port
+- Check SSH key permissions
 
 ### Reverse Proxy Issues
 
@@ -167,7 +166,7 @@ Warning: using default value for POSTGRES_USER
 # Check service logs
 ftl logs <service>
 
-# Verify server connectivity
+# Verify connectivity
 ftl setup
 
 # Rebuild and redeploy service


### PR DESCRIPTION
This PR removes multi-server deployment support to address several architectural limitations and edge cases that could lead to deployment failures:

- SSL certificate generation via HTTP challenge cannot be properly coordinated across multiple servers without additional orchestration
- Database replication and state management across distributed servers requires explicit configuration that's outside FTL's scope

Changes:
- Update server config in `ftl.yaml` to accept single server definition instead of array
- Remove server selection logic from cli commands
- Update documentation to reflect single-server architecture

The tool's primary goal of simplified deployments is better served by a focused single-server approach. For multi-server deployments, users should consider container orchestration platforms like Kubernetes.
